### PR TITLE
widget: show the bot's configured avatar on the live-agent floating button

### DIFF
--- a/src/chatbot-widget.ts
+++ b/src/chatbot-widget.ts
@@ -20,6 +20,13 @@ interface ConfigurationResponse {
     data: {
         hideBranding: boolean;
         buttonType?: string;
+        // Per-bot widget branding resolved by the app. `avatarUrl` is absolute and always
+        // present (the app applies a default), and is the same image shown in the chat
+        // header inside the iframe — so the floating button can mirror it exactly.
+        branding?: {
+            title?: string;
+            avatarUrl?: string;
+        };
         [key: string]: any;
     };
 }
@@ -36,6 +43,7 @@ class ChatbotWidget {
     private hasValidConfig: boolean = false;
     private hideBranding: boolean = false;
     private buttonType: string = '';
+    private avatarUrl: string = '';
     private configFetched: boolean = false;
 
     constructor(config: ChatbotWidgetConfig = {}) {
@@ -123,6 +131,7 @@ class ChatbotWidget {
             if (data && data.data) {
                 this.hideBranding = data.data.hideBranding;
                 this.buttonType = data.data.buttonType || '';
+                this.avatarUrl = data.data.branding?.avatarUrl || '';
             }
             
             this.configFetched = true;
@@ -509,12 +518,19 @@ class ChatbotWidget {
     }
 
     private getLiveAgentButtonContent(): string {
-        // Use jsdelivr URL for production, local path for development
+        // Bundled fallback image. Used only when the configuration endpoint didn't supply
+        // an avatar URL (older app version, or the config fetch failed). jsdelivr for
+        // production, local path for development.
         const isProduction = this.config.baseUrl === DEFAULT_BASE_URL;
-        const imageUrl = isProduction 
+        const fallbackImageUrl = isProduction
             ? `https://cdn.jsdelivr.net/gh/trysetter/website-widget@releases/assets/live_agent_woman_face.png`
             : `/src/assets/live_agent_woman_face.png`;
-            
+
+        // Prefer the bot's configured avatar (served from the app's own domain). This is
+        // the exact same image the app renders in the chat-window header, so the floating
+        // button and the header always show the same picture.
+        const imageUrl = this.avatarUrl || fallbackImageUrl;
+
         return `
             <img src="${imageUrl}" alt="Live Agent" class="live-agent-image" />
             <div class="availability-indicator"></div>


### PR DESCRIPTION
## What

Makes the **floating live-agent button** show the bot's configured avatar instead of the hardcoded bundled image — so the button and the in-iframe chat-window header always show the **same picture**.

Pairs with the app-side PR **trysetter/AI-Chatbot-App#210**, which adds per-bot widget branding (title + avatar) and exposes a `branding` object on the website-widget configuration endpoint.

## How

`fetchConfiguration()` already reads `hideBranding` + `buttonType` from `/api/v1/bot-integrations/{id}/website-widget/configuration`. That endpoint now also returns:

```jsonc
"data": {
  "hideBranding": false,
  "buttonType": "live_agent",
  "branding": { "title": "…", "avatarUrl": "https://chat.trysetter.com/…" }
}
```

- Read `branding.avatarUrl` into `this.avatarUrl`.
- `getLiveAgentButtonContent()` uses `this.avatarUrl` for the button `<img>`, falling back to the bundled `live_agent_woman_face.png` only when the field is absent (older app version / fetch failure).

`avatarUrl` is **always** populated by the app (default applied) and is the same URL used by the chat header, so the button mirrors the header for both custom and default avatars.

## Scope / notes
- Applies to the **`live_agent`** button type (the one that renders a face). The **`classic`** button stays a chat-bubble SVG by design — no avatar slot. Flag if you want classic to adopt the avatar too.
- `dist/` is built by CI (`npm run build`) on push to `main`, then published to the `releases` branch — only `src/` is changed here.
- `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chatbot widget now supports configurable custom avatar URLs for the Live Agent button, with automatic fallback to default avatars when not specified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trysetter/website-widget/pull/3?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->